### PR TITLE
Link AMD64 status page to images

### DIFF
--- a/content/pages/amd64.rst
+++ b/content/pages/amd64.rst
@@ -3,3 +3,14 @@ Generic AMD64 Status
 
 :status: hidden
 
+Images
+======
+
+Pre-alpha N900 images are available here::
+
+    http://maedevu.maemo.org/images/
+
+Installation
+------------
+
+Images are provided for VirtualBox, QEMU and Vagrant.

--- a/content/pages/amd64.rst
+++ b/content/pages/amd64.rst
@@ -6,7 +6,7 @@ Generic AMD64 Status
 Images
 ======
 
-Pre-alpha N900 images are available here::
+Pre-alpha images for generic AMD64 systems are available here::
 
     http://maedevu.maemo.org/images/
 


### PR DESCRIPTION
Having images link from the architectures page should make it easier for people to find them.